### PR TITLE
Pin ZMK release and disable 2M PHY

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,4 +2,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3.0

--- a/config/ergonaut_one.conf
+++ b/config/ergonaut_one.conf
@@ -13,3 +13,6 @@ CONFIG_ZMK_USB=y
 CONFIG_ZMK_BLE=y
 
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
+
+# Work around pairing/reconnect loops seen with some Windows Bluetooth adapters.
+CONFIG_BT_CTLR_PHY_2M=n

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3.0
       import: app/west.yml
     - name: ergonautkb-zmk-module
       remote: ergonautkb


### PR DESCRIPTION
This PR pins the user config to the stable ZMK v0.3.0 release and disables Bluetooth 2M PHY.

Context:
- On an Ergonaut One with Seeed XIAO BLE controllers, the current main-based build repeatedly connected/disconnected on Windows after a single RESET or after a power cycle.
- The keyboard paired successfully immediately after settings_reset, but the reconnect loop returned after reboot.
- The same behavior reproduced when either controller was flashed as the central/left half, making a single bad controller or soldering issue less likely.
- A test build with these changes was flashed and verified to reconnect normally after reset/power cycle.

Changes:
- Pin config/west.yml to ZMK v0.3.0 instead of tracking main.
- Pin the shared GitHub Actions workflow to v0.3.0.
- Add CONFIG_BT_CTLR_PHY_2M=n, which ZMK documents as a workaround for pairing/connect issues with some Windows Bluetooth adapters.

Notes:
- This intentionally does not include PR #9 keymap-drawer changes, to keep the Bluetooth stability change focused.
- This intentionally does not switch to xiao_ble//zmk from PR #12, because the purpose here is a stable release-pinned build.