### PR TITLE
Maintenance - Zephyr 4.1 update

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,17 +1,7 @@
 include:
-  - board: seeeduino_xiao_ble
+  - board: seeeduino_xiao
     shield: ergonaut_one_left
-  - board: seeeduino_xiao_ble
+  - board: seeeduino_xiao
     shield: ergonaut_one_right
-  - board: seeeduino_xiao_ble
-    shield: ergonaut_one_left
-    snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
-    artifact-name: ergonaut_one_left_studio
-  - board: seeeduino_xiao_ble
-    shield: ergonaut_one_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
-    artifact-name: ergonaut_one_right_studio
-  - board: seeeduino_xiao_ble
+  - board: seeeduino_xiao
     shield: settings_reset

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 include:
-  - board: seeeduino_xiao
+  - board: xiao_ble//zmk
     shield: ergonaut_one_left
-  - board: seeeduino_xiao
+  - board: xiao_ble//zmk
     shield: ergonaut_one_right
-  - board: seeeduino_xiao
+  - board: xiao_ble//zmk
     shield: settings_reset


### PR DESCRIPTION
The [Zephyr 4.1 update](https://zmk.dev/blog/2025/12/09/zephyr-4-1#zmk-board-variant.) requires a change to the board name.